### PR TITLE
Feature/issue 29 dynamic controls

### DIFF
--- a/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
+++ b/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
@@ -19,7 +19,7 @@ public class DynamicControlsPage extends BasePage {
     private static final String disableButtonText = "Disable";
 
     private static final By checkboxSelector = By.id("checkbox");
-    private static final By inputFormSelector = By.cssSelector("input");
+    private static final By inputFormSelector = By.id("input-example");
 
     private static final int secondsToWaitForChanges = 4;
 
@@ -74,7 +74,7 @@ public class DynamicControlsPage extends BasePage {
     }
 
     public boolean isInputFormEnabled() {
-        WebElement inputForm = getDriver().findElementQuietly(inputFormSelector);
+        WebElement inputForm = getDriver().findElementQuietly(inputFormSelector).findElement(By.cssSelector("input"));
         return inputForm.isEnabled();
     }
 }

--- a/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
+++ b/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
@@ -15,6 +15,8 @@ public class DynamicControlsPage extends BasePage {
 
     private static final String removeButtonText = "Remove";
     private static final String addButtonText = "Add";
+    private static final String enableButtonText = "Enable";
+    private static final String disableButtonText = "Disable";
     private static final By checkboxSelector = By.id("checkbox");
     private static final int secondsToWaitForChanges = 4;
 
@@ -44,6 +46,15 @@ public class DynamicControlsPage extends BasePage {
     public void clickAddButton() {
         findButtonByText(addButtonText).get().click();
     }
+
+    public void clickEnableButton() {
+        findButtonByText(enableButtonText).get().click();
+    }
+
+    public void clickDisableButton() {
+        findButtonByText(disableButtonText).get().click();
+    }
+
 
     public Optional<WebElement> findButtonByText(String textOnButton) {
         By buttonSelector = By.cssSelector("button");

--- a/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
+++ b/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
@@ -26,4 +26,15 @@ public class DynamicControlsPage extends BasePage {
 		return getActualPageTitle();
 	}
 
+	public void clickRemoveButton(){
+
+	}
+
+	public boolean isCheckboxOnPage() {
+
+	}
+
+	public void waitUntilLoadingIsDone() {
+
+	}
 }

--- a/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
+++ b/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
@@ -13,7 +13,8 @@ import java.util.concurrent.TimeUnit;
 
 public class DynamicControlsPage extends BasePage {
 
-    private static final String removeButtonText = "Remove"; // By.id("checkbox-example").findElement("Remove")
+    private static final String removeButtonText = "Remove";
+    private static final String addButtonText = "Add";
     private static final By checkboxSelector = By.id("checkbox");
     private static final int secondsToWaitForChanges = 4;
 
@@ -38,6 +39,10 @@ public class DynamicControlsPage extends BasePage {
 
     public void clickRemoveButton() {
         findButtonByText(removeButtonText).get().click();
+    }
+
+    public void clickAddButton() {
+        findButtonByText(addButtonText).get().click();
     }
 
     public Optional<WebElement> findButtonByText(String textOnButton) {

--- a/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
+++ b/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
@@ -17,7 +17,10 @@ public class DynamicControlsPage extends BasePage {
     private static final String addButtonText = "Add";
     private static final String enableButtonText = "Enable";
     private static final String disableButtonText = "Disable";
+
     private static final By checkboxSelector = By.id("checkbox");
+    private static final By inputFormSelector = By.cssSelector("input");
+
     private static final int secondsToWaitForChanges = 4;
 
     @Override
@@ -68,5 +71,10 @@ public class DynamicControlsPage extends BasePage {
 
     public void waitUntilLoadingIsDone() throws InterruptedException {
         TimeUnit.SECONDS.sleep(secondsToWaitForChanges);
+    }
+
+    public boolean isInputFormEnabled() {
+        WebElement inputForm = getDriver().findElementQuietly(inputFormSelector);
+        return inputForm.isEnabled();
     }
 }

--- a/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
+++ b/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
@@ -4,37 +4,57 @@ import com.capgemini.mrchecker.selenium.core.BasePage;
 import com.capgemini.mrchecker.selenium.pages.environment.GetEnvironmentParam;
 import com.capgemini.mrchecker.selenium.pages.environment.PageSubURLsProjectYEnum;
 import com.capgemini.mrchecker.test.core.logger.BFLogger;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import java.sql.Time;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 public class DynamicControlsPage extends BasePage {
 
-	@Override
-	public boolean isLoaded() {
-		getDriver().waitForPageLoaded();
-		return getDriver().getCurrentUrl()
-				.contains(PageSubURLsProjectYEnum.DYNAMIC_CONTROLS.getValue());
-	}
+    private static final String removeButtonText = "Remove"; // By.id("checkbox-example").findElement("Remove")
+    private static final By checkboxSelector = By.id("checkbox");
+    private static final int secondsToWaitForChanges = 4;
 
-	@Override
-	public void load() {
-		BFLogger.logDebug("Load 'Dynamic Controls' page.");
-		getDriver().get(GetEnvironmentParam.THE_INTERNET_MAIN_PAGE.getValue() + PageSubURLsProjectYEnum.DYNAMIC_CONTROLS.getValue());
-		getDriver().waitForPageLoaded();
-	}
+    @Override
+    public boolean isLoaded() {
+        getDriver().waitForPageLoaded();
+        return getDriver().getCurrentUrl()
+                .contains(PageSubURLsProjectYEnum.DYNAMIC_CONTROLS.getValue());
+    }
 
-	@Override
-	public String pageTitle() {
-		return getActualPageTitle();
-	}
+    @Override
+    public void load() {
+        BFLogger.logDebug("Load 'Dynamic Controls' page.");
+        getDriver().get(GetEnvironmentParam.THE_INTERNET_MAIN_PAGE.getValue() + PageSubURLsProjectYEnum.DYNAMIC_CONTROLS.getValue());
+        getDriver().waitForPageLoaded();
+    }
 
-	public void clickRemoveButton(){
+    @Override
+    public String pageTitle() {
+        return getActualPageTitle();
+    }
 
-	}
+    public void clickRemoveButton() {
+        findButtonByText(removeButtonText).get().click();
+    }
 
-	public boolean isCheckboxOnPage() {
+    public Optional<WebElement> findButtonByText(String textOnButton) {
+        By buttonSelector = By.cssSelector("button");
+        return getDriver().findElementDynamics(buttonSelector).stream().filter(element -> element.getText().equals(textOnButton)).findFirst();
+    }
 
-	}
+    public boolean isCheckboxOnPage() {
+        WebElement checkbox = getDriver().findElementQuietly(checkboxSelector);
+        return checkbox != null;
+    }
 
-	public void waitUntilLoadingIsDone() {
-
-	}
+    public void waitUntilLoadingIsDone() {
+        try {
+            TimeUnit.SECONDS.sleep(secondsToWaitForChanges);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
+++ b/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
@@ -20,6 +20,7 @@ public class DynamicControlsPage extends BasePage {
 
     private static final By checkboxSelector = By.id("checkbox");
     private static final By inputFormSelector = By.id("input-example");
+    private static final By inputSelector = By.cssSelector("input");
 
     private static final int secondsToWaitForChanges = 4;
 
@@ -69,12 +70,19 @@ public class DynamicControlsPage extends BasePage {
         return checkbox != null;
     }
 
+    /**
+     * Waits few seconds until dynamic element loading is done.
+     * Implementation is simplified to
+     * {@code Thread.sleep(few seconds)}
+     *
+     * @throws InterruptedException
+     */
     public void waitUntilLoadingIsDone() throws InterruptedException {
         TimeUnit.SECONDS.sleep(secondsToWaitForChanges);
     }
 
     public boolean isInputFormEnabled() {
-        WebElement inputForm = getDriver().findElementQuietly(inputFormSelector).findElement(By.cssSelector("input"));
+        WebElement inputForm = getDriver().findElementQuietly(inputFormSelector).findElement(inputSelector);
         return inputForm.isEnabled();
     }
 }

--- a/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
+++ b/example/src/main/java/com/capgemini/mrchecker/selenium/pages/projectY/DynamicControlsPage.java
@@ -50,11 +50,7 @@ public class DynamicControlsPage extends BasePage {
         return checkbox != null;
     }
 
-    public void waitUntilLoadingIsDone() {
-        try {
-            TimeUnit.SECONDS.sleep(secondsToWaitForChanges);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+    public void waitUntilLoadingIsDone() throws InterruptedException {
+        TimeUnit.SECONDS.sleep(secondsToWaitForChanges);
     }
 }

--- a/example/src/test/java/com/capgemini/mrchecker/selenium/projectY/DynamicControlsTest.java
+++ b/example/src/test/java/com/capgemini/mrchecker/selenium/projectY/DynamicControlsTest.java
@@ -55,16 +55,17 @@ public class DynamicControlsTest extends TheInternetBaseTest {
         dynamicControlsPage.waitUntilLoadingIsDone();
         isInputFormEnabled = dynamicControlsPage.isInputFormEnabled();
 
-        assertFalse("InputForm is enabled", isInputFormEnabled);
+        assertTrue("InputForm is not enabled", isInputFormEnabled);
 
         logStep("Click disable button");
         dynamicControlsPage.clickDisableButton();
 
         logStep("Wait few seconds to finish loading");
         dynamicControlsPage.waitUntilLoadingIsDone();
-        isInputFormEnabled = dynamicControlsPage.isCheckboxOnPage();
+        dynamicControlsPage.waitUntilLoadingIsDone();
+        isInputFormEnabled = dynamicControlsPage.isInputFormEnabled();
 
-        assertTrue("InputForm is disabled", isInputFormEnabled);
+        assertFalse("InputForm is not disabled", isInputFormEnabled);
     }
 
 

--- a/example/src/test/java/com/capgemini/mrchecker/selenium/projectY/DynamicControlsTest.java
+++ b/example/src/test/java/com/capgemini/mrchecker/selenium/projectY/DynamicControlsTest.java
@@ -10,7 +10,6 @@ public class DynamicControlsTest extends TheInternetBaseTest {
 
     private DynamicControlsPage dynamicControlsPage;
     private boolean isCheckboxOnPage;
-    private boolean isInputFormEnabled;
 
     @Override
     public void setUp() {
@@ -19,7 +18,7 @@ public class DynamicControlsTest extends TheInternetBaseTest {
         logStep("Verify if Dynamic Controls page is opened");
         assertTrue("Unable to open Dynamic Controls page", dynamicControlsPage.isLoaded());
 
-        logStep("Verify if checkbox is visible before dynamic hide");
+        logStep("Verify if checkbox is visible on page load");
         isCheckboxOnPage = dynamicControlsPage.isCheckboxOnPage();
         assertTrue("Checkbox is not present ", isCheckboxOnPage);
     }
@@ -53,7 +52,7 @@ public class DynamicControlsTest extends TheInternetBaseTest {
 
         logStep("Wait few seconds to finish loading");
         dynamicControlsPage.waitUntilLoadingIsDone();
-        isInputFormEnabled = dynamicControlsPage.isInputFormEnabled();
+        boolean isInputFormEnabled = dynamicControlsPage.isInputFormEnabled();
 
         assertTrue("InputForm is not enabled", isInputFormEnabled);
 
@@ -62,10 +61,9 @@ public class DynamicControlsTest extends TheInternetBaseTest {
 
         logStep("Wait few seconds to finish loading");
         dynamicControlsPage.waitUntilLoadingIsDone();
-        dynamicControlsPage.waitUntilLoadingIsDone();
-        isInputFormEnabled = dynamicControlsPage.isInputFormEnabled();
+        boolean isInputFormDisabled = !dynamicControlsPage.isInputFormEnabled();
 
-        assertFalse("InputForm is not disabled", isInputFormEnabled);
+        assertTrue("InputForm is not disabled", isInputFormDisabled);
     }
 
 

--- a/example/src/test/java/com/capgemini/mrchecker/selenium/projectY/DynamicControlsTest.java
+++ b/example/src/test/java/com/capgemini/mrchecker/selenium/projectY/DynamicControlsTest.java
@@ -25,7 +25,7 @@ public class DynamicControlsTest extends TheInternetBaseTest {
 
 
     @Test
-    public void shouldRemoveCheckboxAfterButtonClickAndWaitProcess() throws InterruptedException {
+    public void shouldRemoveAndAddCheckboxDynamically() throws InterruptedException {
         logStep("Click remove button");
         dynamicControlsPage.clickRemoveButton();
 
@@ -34,6 +34,15 @@ public class DynamicControlsTest extends TheInternetBaseTest {
         isCheckboxOnPage = dynamicControlsPage.isCheckboxOnPage();
 
         assertFalse("Checkbox has not disappeared", isCheckboxOnPage);
+
+        logStep("Click add button");
+        dynamicControlsPage.clickAddButton();
+
+        logStep("Wait few seconds to finish loading");
+        dynamicControlsPage.waitUntilLoadingIsDone();
+        isCheckboxOnPage = dynamicControlsPage.isCheckboxOnPage();
+
+        assertTrue("Checkbox has not disappeared", isCheckboxOnPage);
     }
 
 

--- a/example/src/test/java/com/capgemini/mrchecker/selenium/projectY/DynamicControlsTest.java
+++ b/example/src/test/java/com/capgemini/mrchecker/selenium/projectY/DynamicControlsTest.java
@@ -9,23 +9,21 @@ import static org.junit.Assert.assertTrue;
 
 public class DynamicControlsTest extends TheInternetBaseTest{
 
-    private static DynamicControlsPage dynamicControlsPage;
+    private DynamicControlsPage dynamicControlsPage;
     boolean isCheckboxOnPage;
 
-    @BeforeClass
-    public static void setUpBeforeClass() {
+    @Override
+    public void setUp() {
         dynamicControlsPage = shouldTheInternetPageBeOpened().clickDynamicControlsLink();
 
         logStep("Verify if Dynamic Controls page is opened");
         assertTrue("Unable to open Dynamic Controls page", dynamicControlsPage.isLoaded());
-    }
 
-    @Test
-    public void shouldHaveCheckboxOnLoad(){
+        logStep("Verify if checkobx is visible before dynamic hide");
         isCheckboxOnPage = dynamicControlsPage.isCheckboxOnPage();
-
         assertTrue("Checkbox is not present ", isCheckboxOnPage);
     }
+
 
     @Test
     public void shouldRemoveCheckboxAfterButtonClickAndWaitProcess(){

--- a/example/src/test/java/com/capgemini/mrchecker/selenium/projectY/DynamicControlsTest.java
+++ b/example/src/test/java/com/capgemini/mrchecker/selenium/projectY/DynamicControlsTest.java
@@ -1,0 +1,41 @@
+package com.capgemini.mrchecker.selenium.projectY;
+
+import com.capgemini.mrchecker.selenium.pages.projectY.DynamicControlsPage;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DynamicControlsTest extends TheInternetBaseTest{
+
+    private static DynamicControlsPage dynamicControlsPage;
+    boolean isCheckboxOnPage;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        dynamicControlsPage = shouldTheInternetPageBeOpened().clickDynamicControlsLink();
+
+        logStep("Verify if Dynamic Controls page is opened");
+        assertTrue("Unable to open Dynamic Controls page", dynamicControlsPage.isLoaded());
+    }
+
+    @Test
+    public void shouldHaveCheckboxOnLoad(){
+        isCheckboxOnPage = dynamicControlsPage.isCheckboxOnPage();
+
+        assertTrue("Checkbox is not present ", isCheckboxOnPage);
+    }
+
+    @Test
+    public void shouldRemoveCheckboxAfterButtonClickAndWaitProcess(){
+        dynamicControlsPage.clickRemoveButton();
+        dynamicControlsPage.waitUntilLoadingIsDone();
+
+        isCheckboxOnPage = dynamicControlsPage.isCheckboxOnPage();
+
+        assertFalse("Checkbox has not disappeared", isCheckboxOnPage);
+    }
+
+
+}

--- a/example/src/test/java/com/capgemini/mrchecker/selenium/projectY/DynamicControlsTest.java
+++ b/example/src/test/java/com/capgemini/mrchecker/selenium/projectY/DynamicControlsTest.java
@@ -1,13 +1,12 @@
 package com.capgemini.mrchecker.selenium.projectY;
 
 import com.capgemini.mrchecker.selenium.pages.projectY.DynamicControlsPage;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class DynamicControlsTest extends TheInternetBaseTest{
+public class DynamicControlsTest extends TheInternetBaseTest {
 
     private DynamicControlsPage dynamicControlsPage;
     boolean isCheckboxOnPage;
@@ -19,17 +18,19 @@ public class DynamicControlsTest extends TheInternetBaseTest{
         logStep("Verify if Dynamic Controls page is opened");
         assertTrue("Unable to open Dynamic Controls page", dynamicControlsPage.isLoaded());
 
-        logStep("Verify if checkobx is visible before dynamic hide");
+        logStep("Verify if checkbox is visible before dynamic hide");
         isCheckboxOnPage = dynamicControlsPage.isCheckboxOnPage();
         assertTrue("Checkbox is not present ", isCheckboxOnPage);
     }
 
 
     @Test
-    public void shouldRemoveCheckboxAfterButtonClickAndWaitProcess(){
+    public void shouldRemoveCheckboxAfterButtonClickAndWaitProcess() throws InterruptedException {
+        logStep("Click remove button");
         dynamicControlsPage.clickRemoveButton();
-        dynamicControlsPage.waitUntilLoadingIsDone();
 
+        logStep("Wait few seconds to finish loading");
+        dynamicControlsPage.waitUntilLoadingIsDone();
         isCheckboxOnPage = dynamicControlsPage.isCheckboxOnPage();
 
         assertFalse("Checkbox has not disappeared", isCheckboxOnPage);

--- a/example/src/test/java/com/capgemini/mrchecker/selenium/projectY/DynamicControlsTest.java
+++ b/example/src/test/java/com/capgemini/mrchecker/selenium/projectY/DynamicControlsTest.java
@@ -9,7 +9,8 @@ import static org.junit.Assert.assertTrue;
 public class DynamicControlsTest extends TheInternetBaseTest {
 
     private DynamicControlsPage dynamicControlsPage;
-    boolean isCheckboxOnPage;
+    private boolean isCheckboxOnPage;
+    private boolean isInputFormEnabled;
 
     @Override
     public void setUp() {
@@ -43,6 +44,27 @@ public class DynamicControlsTest extends TheInternetBaseTest {
         isCheckboxOnPage = dynamicControlsPage.isCheckboxOnPage();
 
         assertTrue("Checkbox has not disappeared", isCheckboxOnPage);
+    }
+
+    @Test
+    public void shouldEnableAndDisableInputFormDynamically() throws InterruptedException {
+        logStep("Click enable button");
+        dynamicControlsPage.clickEnableButton();
+
+        logStep("Wait few seconds to finish loading");
+        dynamicControlsPage.waitUntilLoadingIsDone();
+        isInputFormEnabled = dynamicControlsPage.isInputFormEnabled();
+
+        assertFalse("InputForm is enabled", isInputFormEnabled);
+
+        logStep("Click disable button");
+        dynamicControlsPage.clickDisableButton();
+
+        logStep("Wait few seconds to finish loading");
+        dynamicControlsPage.waitUntilLoadingIsDone();
+        isInputFormEnabled = dynamicControlsPage.isCheckboxOnPage();
+
+        assertTrue("InputForm is disabled", isInputFormEnabled);
     }
 
 


### PR DESCRIPTION
Dynamic controls page with tests have been added.
In tests we have to wait few seconds for element loading finish. I`ve decided to simplify it just to sleep thread for few seconds which is enough to pass that tests as long as the website is not changed. It is possible to do it in more professional way (e.g. using concurrency), but to do it well, it would be tricky and reader could be confused. If such method is needed that it should be treated as another feature placed in main source project.