### PR TITLE
devonfw name typo fixed

### DIFF
--- a/documentation/master-mrchecker.asciidoc
+++ b/documentation/master-mrchecker.asciidoc
@@ -1,4 +1,4 @@
-= MrChecker - devon testing tool
+= MrChecker - devonfw testing tool
 
 == Who Is MrChecker
 


### PR DESCRIPTION
Please, remember that the correct name of the platform is **devonfw** in lowercase and not _devon_, _Devon_, _DevonFW_, etc. as it is stated in the trademark. 

This is just a typo fixed.  